### PR TITLE
[#1] Do not convert non-ASCII argument terms to charlist

### DIFF
--- a/lib/ex_azure/utils.ex
+++ b/lib/ex_azure/utils.ex
@@ -7,6 +7,64 @@ defmodule ExAzure.Utils do
   end
 
   def normalize_to_charlist(term) do
-    if String.valid?(term), do: to_charlist(term), else: term
+    with \
+      true <- String.valid?(term),
+      charlist <- Kernel.to_charlist(term),
+      true <- ascii_printable?(charlist)
+    do
+      charlist
+    else
+      _ ->
+        term
+    end
   end
+
+  defp ascii_printable?(list, counter \\ :infinity)
+
+  defp ascii_printable?(_, 0) do
+    true
+  end
+
+  defp ascii_printable?([char | rest], counter)
+      when is_integer(char) and char >= 32 and char <= 126 do
+    ascii_printable?(rest, decrement(counter))
+  end
+
+  defp ascii_printable?([?\n | rest], counter) do
+    ascii_printable?(rest, decrement(counter))
+  end
+
+  defp ascii_printable?([?\r | rest], counter) do
+    ascii_printable?(rest, decrement(counter))
+  end
+
+  defp ascii_printable?([?\t | rest], counter) do
+    ascii_printable?(rest, decrement(counter))
+  end
+
+  defp ascii_printable?([?\v | rest], counter) do
+    ascii_printable?(rest, decrement(counter))
+  end
+
+  defp ascii_printable?([?\b | rest], counter) do
+    ascii_printable?(rest, decrement(counter))
+  end
+
+  defp ascii_printable?([?\f | rest], counter) do
+    ascii_printable?(rest, decrement(counter))
+  end
+
+  defp ascii_printable?([?\e | rest], counter) do
+    ascii_printable?(rest, decrement(counter))
+  end
+
+  defp ascii_printable?([?\a | rest], counter) do
+    ascii_printable?(rest, decrement(counter))
+  end
+
+  defp ascii_printable?([], _counter), do: true
+  defp ascii_printable?(_, _counter), do: false
+
+  defp decrement(:infinity), do: :infinity
+  defp decrement(counter), do: counter - 1
 end


### PR DESCRIPTION
`ascii_printable?` has been lifted directly from the Elixir standard lib for Elixir 1.6 (https://github.com/elixir-lang/elixir/blob/v1.6.2/lib/elixir/lib/list.ex#L469). Chose to duplicate the function so this library would be backwards-compatible with previous Elixir versions.