### PR TITLE
Add xmerl in extra applications

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -40,4 +40,3 @@ defmodule ExAzure.Mixfile do
     ]
   end
 end
-˜

--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,8 @@ defmodule ExAzure.Mixfile do
 
   def application do
     [applications: [:erlazure],
-     mod: {ExAzure, []}]
+    extra_applications: [:xmerl],
+    mod: {ExAzure, []}]
   end
 
   defp deps do
@@ -39,3 +40,4 @@ defmodule ExAzure.Mixfile do
     ]
   end
 end
+˜


### PR DESCRIPTION
Description
---
In release only, I had a bug where I tried to delete a none existing blob on the azure storage, which resulted into a `function :xmerl_scan.string/1` error. In release, the `:xmerl` module to parse the XML error response from the storage was missing. 

I think the OTP dependencies should come from the library that is using them. 

Test
---
In my app, I added the `:xmerl` external application, and this fixes the issue. 